### PR TITLE
Refactor rest client to improve readability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    music_today_api_wrapper (12.15)
+    music_today_api_wrapper (16.12.15.03)
       bundler (>= 1.10.6)
       json (~> 1.8, >= 1.8.3)
       rake (>= 10.4.2)
@@ -13,6 +13,7 @@ GEM
     adamantium (0.2.0)
       ice_nine (~> 0.11.0)
       memoizable (~> 0.4.0)
+    addressable (2.4.0)
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
@@ -28,11 +29,14 @@ GEM
     concord (0.1.5)
       adamantium (~> 0.2.0)
       equalizer (~> 0.0.9)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.2.5)
     dotenv (2.0.2)
     equalizer (0.0.11)
+    hashdiff (0.2.3)
     ice_nine (0.11.1)
     json (1.8.3)
     memoizable (0.4.2)
@@ -71,6 +75,7 @@ GEM
       ruby-progressbar (~> 1.7)
       tins (<= 1.6.0)
     ruby-progressbar (1.7.5)
+    safe_yaml (1.0.4)
     spork (0.9.2)
     thread_safe (0.3.5)
     tins (1.6.0)
@@ -82,11 +87,16 @@ GEM
       equalizer (~> 0.0.9)
       parser (~> 2.2.2)
       procto (~> 0.0.2)
+    vcr (3.0.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    webmock (1.22.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -99,6 +109,8 @@ DEPENDENCIES
   rspec (~> 3.3)
   rubocop (~> 0.35.1)
   spork (~> 0.9.2)
+  vcr (~> 3.0)
+  webmock (~> 1.22)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/rest_clients/music_today_rest_client.rb
+++ b/lib/rest_clients/music_today_rest_client.rb
@@ -16,22 +16,31 @@ module MusicTodayApiWrapper
 
     def all_products
       @common_response.work do
-        uri =
-          URI("#{@url}/catalog/content/#{@catalog_number}/?apiuser=#{@user}&"\
-          "apikey=#{@api_key}")
-        res = Net::HTTP.get_response(uri)
-        @common_response.data[:products] = JSON.parse(res.body)['products']
+        url = "#{@url}/catalog/content/#{@catalog_number}/"
+
+        @common_response.data[:products] = get(url)['products']
       end
     end
 
     def find_product(product_id)
       @common_response.work do
-        uri =
-          URI("#{@url}/catalog/product/#{@catalog_number}/#{product_id}?"\
-          "apiuser=#{@user}&apikey=#{@api_key}")
-        res = Net::HTTP.get_response(uri)
-        @common_response.data[:product] = JSON.parse(res.body)['product']
+        url = "#{@url}/catalog/product/#{@catalog_number}/#{product_id}"
+
+        @common_response.data[:product] = get(url)['product']
       end
+    end
+
+    private
+
+    def get(url, options = {})
+      options.merge!(apiuser: @user, apikey: @api_key)
+
+      uri = URI(url)
+      uri.query = URI.encode_www_form(options)
+
+      response = Net::HTTP.get_response(uri)
+
+      JSON.parse(response.body)
     end
   end
 end

--- a/music_today_api_wrapper.gemspec
+++ b/music_today_api_wrapper.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 0.35.1'
   s.add_development_dependency 'spork', '~> 0.9.2'
   s.add_development_dependency 'vcr', '~> 3.0'
+  s.add_development_dependency 'webmock', '~> 1.22'
 
   s.add_dependency 'bundler', '>= 1.10.6'
   s.add_dependency 'rake', '>= 10.4.2'


### PR DESCRIPTION
Also added `s.add_development_dependency 'webmock', '~> 1.22'` because specs wouldn't run without it.
